### PR TITLE
Fix 8 Function argument (EML path) overwrite in `publish_data_edi()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -11,7 +11,8 @@ Imports:
     lubridate,
     purrr,
     readr,
-    tidyr
+    tidyr,
+    stringr
 Remotes:
     EDIorg/EMLassemblyline,
     FlowWest/EMLaide

--- a/R/publish-data-edi.R
+++ b/R/publish-data-edi.R
@@ -21,15 +21,18 @@
 #' publish on the staging environment first to review the data package and then
 #' publish to production. Option are: `staging`, `production`
 #'
+#' @param path_eml_file Path to the EML `.xml` file. Defaults to
+#' `publish/eml/<edi_number>.xml`, which is where [make_eml_edi()] writes its
+#' output. Override this argument if your EML file lives elsewhere.
+#'
 #' @return A message describing if the upload was successful or not.
 #'
 #' @export
-publish_data_edi <- function(path_eml_file, publish_type, edi_number, publish_environment) {
-
-  path_eml_file <- here("data-raw", "eml", paste0(edi_number, ".xml")) # Created using make-metadata-eml.R
+publish_data_edi <- function(publish_type, edi_number, publish_environment,
+                             path_eml_file = here::here("publish", "eml", paste0(edi_number, ".xml"))) {
 
   if (publish_type == "update") {
-    parts <- str_split(edi_number, "\\.")[[1]]
+    parts <- stringr::str_split(edi_number, "\\.")[[1]]
     parts[length(parts)] <- as.character(as.numeric(parts[length(parts)]) - 1)
     existing_edi_number <- paste(parts, collapse = ".")
 

--- a/man/publish_data_edi.Rd
+++ b/man/publish_data_edi.Rd
@@ -4,7 +4,12 @@
 \alias{publish_data_edi}
 \title{Publish data package on EDI}
 \usage{
-publish_data_edi(path_eml_file, publish_type, edi_number, publish_environment)
+publish_data_edi(
+  publish_type,
+  edi_number,
+  publish_environment,
+  path_eml_file = here::here("publish", "eml", paste0(edi_number, ".xml"))
+)
 }
 \arguments{
 \item{publish_type}{Indicate whether you are publishing an update to an existing
@@ -17,6 +22,10 @@ the EDI number will be one version greater than the existing package.}
 \item{publish_environment}{Environment where data are being published. Recommended to
 publish on the staging environment first to review the data package and then
 publish to production. Option are: \code{staging}, \code{production}}
+
+\item{path_eml_file}{Path to the EML \code{.xml} file. Defaults to
+\verb{publish/eml/<edi_number>.xml}, which is where \code{\link[=make_eml_edi]{make_eml_edi()}} writes its
+output. Override this argument if your EML file lives elsewhere.}
 }
 \value{
 A message describing if the upload was successful or not.


### PR DESCRIPTION
This PR is to resolve #8:

- Removed the line inside `publish_data_edi()` that hardcoded and overwrote the `path_eml_file` argument, making the parameter effectively ignored
- Updated the default value of `path_eml_file` to `publish/eml/<edi_number>.xml`, matching the output location of `make_eml_edi()`
- Added `@param` documentation for `path_eml_file`
- Regenerated `publish_data_edi()` function documentation

Bonus changes: 

- Added `stringr` to `Imports` in `DESCRIPTION` and namespaced the existing `str_split()` call accordingly in `publish_data_edi()`